### PR TITLE
Remove duplicate "id" parameter

### DIFF
--- a/reference/ImmutableX-API-OpenAPI3.yaml
+++ b/reference/ImmutableX-API-OpenAPI3.yaml
@@ -62,12 +62,6 @@ paths:
                 $ref: '#/components/schemas/Application'
       operationId: getApplicationDetails
       description: Get details of an application with the given ID
-      parameters:
-        - schema:
-            type: string
-          in: query
-          name: id
-          description: Application ID
       tags:
         - applications
   /v1/assets:


### PR DESCRIPTION
this is listed as being in both the URL path and the URL query, but the API has it just in the path. this also prevents invalid TS from being generated for this api